### PR TITLE
Changed tutorial link to point to docs instead GH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Vaadin Spring tutorial
 
 This project contains the source code for the tutorial for using Vaadin and Spring together with the help of Spring Boot.
 
-The tutorial can be found [here](https://github.com/vaadin/flow-and-components-documentation/tree/master/documentation/spring).
+The tutorial can be found [here](https://vaadin.com/docs/v14/flow/spring/tutorial-spring-basic.html).
 
 The topics that are covered in this tutorial project:
 * Getting Started with Vaadin Spring for Flow and Spring Boot: the initial `@SpringBootApplication` class.


### PR DESCRIPTION
This link points to same documentation, but on the website instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-spring-examples/52)
<!-- Reviewable:end -->
